### PR TITLE
fix: or operation style type

### DIFF
--- a/src/weebp.c
+++ b/src/weebp.c
@@ -541,7 +541,7 @@ errcheck:
     style &= and;
     exstyle &= ex_and;
     style |= or;
-    style |= ex_or;
+    exstyle |= ex_or;
 
     SetLastError(0);
 


### PR DESCRIPTION
just a typo, it's actually have no affect, cuz `ex_or` always 0